### PR TITLE
Fix typo in README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ import { resolve } from "../../remote-component.config.js";
 
 const url = "https://raw.githubusercontent.com/Paciolan/remote-component/master/examples/remote-components/HelloWorld.js"; // prettier-ignore
 const requires = createRequires(resolve);
-const useRemoteComponent = createUseRemoteComponent({ require });
+const useRemoteComponent = createUseRemoteComponent({ requires });
 
 const HelloWorld = props => {
   const [loading, err, Component] = useRemoteComponent(url);


### PR DESCRIPTION
This PR fixes a typo in one of the examples in README - the name of the argument is `requires`, as is the name of the variable passed.